### PR TITLE
[Warlock] Remove reference to Shadow Embrace talent

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -987,7 +987,7 @@ void warlock_t::create_apl_affliction()
 
   def->add_action( "call_action_list,name=item", "Catch-all item usage for anything not specified elsewhere" );
 
-  def->add_action( "call_action_list,name=se,if=talent.shadow_embrace&(debuff.shadow_embrace.stack<(2-action.shadow_bolt.in_flight)|debuff.shadow_embrace.remains<3)", "If talented, Refresh Shadow Embrace before spending shards on Malefic Rapture" );
+  def->add_action( "call_action_list,name=se,if=debuff.shadow_embrace.stack<(2-action.shadow_bolt.in_flight)|debuff.shadow_embrace.remains<3", "Refresh Shadow Embrace before spending shards on Malefic Rapture" );
 
   def->add_action( "malefic_rapture,if=(dot.vile_taint.ticking|dot.impending_catastrophe_dot.ticking|dot.soul_rot.ticking)&(!runeforge.malefic_wrath|buff.malefic_wrath.stack<3|soul_shard>1)", "Use Malefic Rapture when major dots are up, or if there will be significant time until the next Phantom Singularity. If utilizing Malefic Wrath, hold a shard to refresh the buff" );
   def->add_action( "malefic_rapture,if=runeforge.malefic_wrath&cooldown.soul_rot.remains>20&buff.malefic_wrath.remains<4", "Use Malefic Rapture to maintain the malefic wrath buff until shards need to be generated for the next burst window (20 seconds is more than sufficient to generate 3 shards)" );


### PR DESCRIPTION
Reference to the Shadow Embrace talent was removed to allow the Malefic Wrath changes to be included in a 9.0.5 commit if desired.